### PR TITLE
Build against simphony-common 0.3.0 and liggghts minimum

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ env:
   - SIMPHONY_VERSION=0.2.0
   - SIMPHONY_VERSION=0.2.1
   - SIMPHONY_VERSION=0.2.2
+  - SIMPHONY_VERSION=0.3.0
+  - SIMPHONY_VERSION=8ed81d91dbee89dbdf4a76d55d9b7f92bce773e7
   - SIMPHONY_VERSION=master
 matrix:
   allow_failures:

--- a/simphony_aviz/util.py
+++ b/simphony_aviz/util.py
@@ -61,6 +61,7 @@ def temp_particles_filename():
     yield os.path.join(temp_dir, "particles.xyz")
     shutil.rmtree(temp_dir)
 
+
 # Attributes need to be either a float or integer
 # so that they can be displayed in AViz.
 _SUPPORTED_TYPES = [numpy.float64, numpy.int32]


### PR DESCRIPTION
Build against version 0.3.0 of simphony-common, as well as the "minimum requirement" for simphony-liggghts (currently a commit, a more stable release tag will come when found)
